### PR TITLE
Visual context polish and session naming improvements

### DIFF
--- a/.claude/skills/reset-tmux.md
+++ b/.claude/skills/reset-tmux.md
@@ -1,0 +1,35 @@
+# Reset Tmux Sessions
+
+**WARNING: This kills ALL tmux sessions. Only use when testing config changes.**
+
+## When to Use
+
+- After updating tmux.conf and wanting fresh sessions with new settings
+- After updating shell-helpers.sh session naming conventions
+- Testing new layouts or configurations
+
+## Commands
+
+```bash
+# Kill all tmux sessions
+tmux kill-server
+
+# Or kill sessions one by one (safer)
+tmux list-sessions -F "#{session_name}" | xargs -I {} tmux kill-session -t {}
+```
+
+## After Reset
+
+Recreate your worktree sessions:
+
+```bash
+# Navigate to your worktree and open fresh session
+cd ~/dev/project
+wty main
+```
+
+## Caution
+
+- Unsaved work in tmux panes will be lost
+- Running processes (builds, servers) will be terminated
+- Claude Code sessions in tmux will disconnect

--- a/claude-statusline.sh
+++ b/claude-statusline.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# =============================================================================
+# Portable Dev System - Claude Status Line
+# Red accent for Claude context
+# =============================================================================
+
+# Red color palette for branch variation
+# Muted reds: 131 (af5f5f), 167 (d75f5f), 174 (d78787), 138 (af8787)
+RED_COLORS=("131" "167" "174" "138" "95" "130")
+
+input=$(cat)
+cwd=$(echo "$input" | jq -r '.workspace.current_dir')
+cd "$cwd" 2>/dev/null || exit 0
+
+# Get branch for color hashing
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "main")
+
+# Hash branch name to pick red variant
+hash=$(printf "%s" "$branch" | cksum | cut -d" " -f1)
+color_idx=$((hash % ${#RED_COLORS[@]}))
+red_code="${RED_COLORS[$color_idx]}"
+
+# ANSI codes for our red accent
+RED="\033[38;5;${red_code}m"
+BOLD_RED="\033[1;38;5;${red_code}m"
+RESET="\033[0m"
+DIM="\033[2m"
+BOLD="\033[1m"
+
+# Red indicator for Claude context
+printf "${BOLD_RED}◆${RESET} "
+
+# Directory (abbreviated)
+dir=$(echo "$cwd" | awk -F'/' '{n=NF; if(n<=3) print $0; else print "~/" $(n-2) "/" $(n-1) "/" $n}' | sed 's|^/Users/rmzi|~|')
+printf "${DIM}%s${RESET}" "$dir"
+
+# Git info
+if git rev-parse --git-dir >/dev/null 2>&1; then
+    printf " on ${BOLD_RED}%s${RESET}" "$branch"
+
+    # Git status
+    untracked=$(git ls-files --others --exclude-standard 2>/dev/null | wc -l | tr -d ' ')
+    modified=$(git diff --name-only 2>/dev/null | wc -l | tr -d ' ')
+    staged=$(git diff --cached --name-only 2>/dev/null | wc -l | tr -d ' ')
+
+    status=""
+    upstream=$(git rev-parse --abbrev-ref @{upstream} 2>/dev/null)
+    if [ -n "$upstream" ]; then
+        ahead=$(git rev-list --count @{upstream}..HEAD 2>/dev/null || echo 0)
+        behind=$(git rev-list --count HEAD..@{upstream} 2>/dev/null || echo 0)
+        [ "$ahead" -gt 0 ] && [ "$behind" -gt 0 ] && status+="⇕⇡${ahead}⇣${behind}"
+        [ "$ahead" -gt 0 ] && [ "$behind" -eq 0 ] && status+="⇡${ahead}"
+        [ "$behind" -gt 0 ] && [ "$ahead" -eq 0 ] && status+="⇣${behind}"
+    fi
+    [ "$untracked" -gt 0 ] && status+="?${untracked}"
+    [ "$modified" -gt 0 ] && status+="!${modified}"
+    [ "$staged" -gt 0 ] && status+="+${staged}"
+
+    [ -n "$status" ] && printf " ${RED}%s${RESET}" "$status"
+fi
+
+# Context window remaining
+remaining=$(echo "$input" | jq -r '.context_window.remaining_percentage // empty')
+if [ -n "$remaining" ]; then
+    if [ "$(echo "$remaining < 20" | bc -l 2>/dev/null || echo 0)" -eq 1 ]; then
+        ctx_color="\033[1;31m"
+    elif [ "$(echo "$remaining < 50" | bc -l 2>/dev/null || echo 0)" -eq 1 ]; then
+        ctx_color="\033[1;33m"
+    else
+        ctx_color="${DIM}"
+    fi
+    printf " ${ctx_color}ctx:%.0f%%${RESET}" "$remaining"
+fi

--- a/docs/install.md
+++ b/docs/install.md
@@ -103,3 +103,45 @@ mkdir -p ~/.config/ghostty && cp ghostty.config ~/.config/ghostty/config
 **When to use Ghostty vs tmux:**
 - **Ghostty**: Local dev, quick sessions, lighter weight
 - **tmux**: Remote SSH, persistent sessions, detach/reattach
+
+### Yazi Theme
+
+For consistent file manager styling with blue accents:
+
+```bash
+mkdir -p ~/.config/yazi && cp yazi-theme.toml ~/.config/yazi/theme.toml
+```
+
+### Claude Status Line
+
+For the red-accented Claude status line:
+
+```bash
+cp claude-statusline.sh ~/.pds/
+chmod +x ~/.pds/claude-statusline.sh
+```
+
+Then update your `~/.claude/settings.json`:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "~/.pds/claude-statusline.sh"
+  }
+}
+```
+
+---
+
+## Visual Context Colors
+
+PDS uses subtle RGB accents to distinguish contexts at a glance:
+
+| Context | Color | Where |
+|---------|-------|-------|
+| Terminal/tmux | Green | Status bar accent |
+| Yazi | Blue | Mode indicator, borders |
+| Claude | Red | Status line marker |
+
+Branch names are hashed to create subtle color variations within each family, so different branches have slightly different hues.

--- a/ghostty.config
+++ b/ghostty.config
@@ -23,7 +23,9 @@ window-padding-y = 8
 window-decoration = true
 
 # macOS only (ignored on Linux)
-macos-titlebar-style = tabs
+# Options: native, transparent, tabs
+# "transparent" keeps the draggable area while being subtle
+macos-titlebar-style = transparent
 
 # -----------------------------------------------------------------------------
 # Shell Integration

--- a/shell-helpers.sh
+++ b/shell-helpers.sh
@@ -122,7 +122,9 @@ function wty() {
 
   command -v branch-tone &>/dev/null && (cd "$dir" && branch-tone "$branch") &>/dev/null &
 
-  local session_name="wt-${branch//\//-}"
+  # Include repo name in session to avoid collisions across projects
+  local repo_name=$(cd "$dir" && basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || basename "$dir")
+  local session_name="${repo_name}-${branch//\//-}"
 
   # Create session if it doesn't exist
   if ! tmux has-session -t "$session_name" 2>/dev/null; then
@@ -267,7 +269,9 @@ function tsk() {
 
 # twt - create/attach tmux session for current worktree
 function twt() {
-  local session_name=$(basename $(pwd))
+  local repo_name=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || basename "$(pwd)")
+  local branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "work")
+  local session_name="${repo_name}-${branch//\//-}"
   if tmux has-session -t "$session_name" 2>/dev/null; then
     tmux attach -t "$session_name"
   else
@@ -278,6 +282,18 @@ function twt() {
 # Quick aliases
 alias tl='tmux list-sessions'
 alias td='tmux detach'
+
+# tmux-reset - kill all tmux sessions (dangerous!)
+function tmux-reset() {
+  echo "⚠️  This will kill ALL tmux sessions!"
+  read -p "Are you sure? (y/n) " -n 1 -r
+  echo ""
+  if [[ $REPLY =~ ^[Yy]$ ]]; then
+    tmux kill-server 2>/dev/null && echo "✓ All sessions killed" || echo "No tmux server running"
+  else
+    echo "Cancelled"
+  fi
+}
 
 # -----------------------------------------------------------------------------
 # Git Aliases

--- a/yazi-theme.toml
+++ b/yazi-theme.toml
@@ -1,0 +1,71 @@
+# =============================================================================
+# Portable Dev System - Yazi Theme
+# Blue accent for file manager context
+# =============================================================================
+
+# Status bar - subtle blue accent
+[status]
+separator_open = ""
+separator_close = ""
+separator_style = { fg = "#5f87af" }
+
+[status.mode_normal]
+bg = "#5f87af"
+fg = "#1c1c1c"
+bold = true
+
+[status.mode_select]
+bg = "#87afd7"
+fg = "#1c1c1c"
+bold = true
+
+[status.mode_unset]
+bg = "#4e4e4e"
+fg = "#bcbcbc"
+bold = true
+
+# Progress bar
+[status.progress_label]
+fg = "#5f87af"
+bold = true
+
+[status.progress_normal]
+fg = "#5f87af"
+
+[status.progress_error]
+fg = "#af5f5f"
+
+# Permissions colors
+[status.permissions_t]
+fg = "#5f87af"
+
+[status.permissions_r]
+fg = "#87af87"
+
+[status.permissions_w]
+fg = "#d7af87"
+
+[status.permissions_x]
+fg = "#af87af"
+
+[status.permissions_s]
+fg = "#4e4e4e"
+
+# Tab bar - blue accent
+[tab]
+active = { fg = "#1c1c1c", bg = "#5f87af", bold = true }
+inactive = { fg = "#bcbcbc", bg = "#303030" }
+
+# Selection marker
+[select]
+marker = { fg = "#5f87af", bold = true }
+
+# File highlighting - subtle blue for selected
+[filetype]
+rules = [
+  { name = "*", is = "selected", bg = "#303040" },
+]
+
+# Border styling
+[border]
+style = { fg = "#5f87af" }


### PR DESCRIPTION
## Summary

- Add yazi theme with blue accents for file manager context
- Add claude-statusline.sh for red-accented Claude status line
- Improve tmux session naming to include repo name (avoids collisions across projects)
- Add `tmux-reset` helper function for killing all sessions
- Update ghostty to use transparent titlebar (subtler look)
- Document visual context colors in install guide

## Test plan

- [ ] Verify yazi theme installs correctly
- [ ] Test claude-statusline.sh with Claude Code
- [ ] Confirm tmux sessions now include repo name prefix
- [ ] Test tmux-reset function

🤖 Generated with [Claude Code](https://claude.com/claude-code)