### PR TITLE
feat: add plugin marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,23 @@
+{
+  "name": "pds-marketplace",
+  "owner": {
+    "name": "rmzi"
+  },
+  "metadata": {
+    "description": "Portable Development System — AI-assisted development methodology"
+  },
+  "plugins": [
+    {
+      "name": "pds",
+      "source": ".",
+      "description": "Portable Development System — skills for consistency, agents for scale.",
+      "version": "4.0.0",
+      "author": {
+        "name": "rmzi"
+      },
+      "repository": "https://github.com/rmzi/portable-dev-system",
+      "keywords": ["sdlc", "agents", "skills", "development"],
+      "category": "productivity"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `.claude-plugin/marketplace.json` so PDS can be installed as a user-level plugin via marketplace

## Install
```
/plugin marketplace add rmzi/portable-dev-system
/plugin install pds@pds-marketplace
```

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>