### PR TITLE
feat: cleanup flag + marketplace install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,23 +11,34 @@
 
 ## Quick Start
 
-### Install (recommended)
+### Install via marketplace (recommended)
+
+Inside Claude Code:
+```
+/plugin marketplace add rmzi/portable-dev-system
+/plugin install pds@pds-marketplace
+```
+
+Restart Claude Code. PDS skills and agents are now available across all projects.
+
+### Install via script
 
 ```bash
 curl -sfL https://raw.githubusercontent.com/rmzi/portable-dev-system/main/install.sh | bash
 ```
 
-Installs the PDS plugin to `~/.claude/plugins/pds/` and security settings to `~/.claude/settings.json`. Works across all projects.
+Installs the plugin to `~/.claude/plugins/pds/` and security settings to `~/.claude/settings.json`.
 
-### Project-level settings (for teams)
+### Upgrading from v3.x?
+
+Clean up old project-level files:
 
 ```bash
 cd ~/your-project
-curl -sfL https://raw.githubusercontent.com/rmzi/portable-dev-system/main/install.sh | bash -s -- --project
-git add .claude CLAUDE.md .gitignore && git commit -m "feat: add PDS project settings"
+curl -sfL https://raw.githubusercontent.com/rmzi/portable-dev-system/main/install.sh | bash -s -- --cleanup
 ```
 
-Installs project-level `settings.json` and `CLAUDE.md` for team-specific overrides. The plugin provides skills and agents.
+See [Migration Guide](docs/migration-v4.md) for details.
 
 ### Dev mode
 
@@ -111,19 +122,15 @@ Blocked:
 
 ---
 
-## For Teams
+## What Lives Where
 
-### What's in the repo vs what's in the plugin
+| Source | What | Example |
+|--------|------|---------|
+| **Plugin** (user-level) | Skills, agents, hooks | `/pds:swarm`, `orchestrator` agent |
+| **Project** (optional) | Team overrides, project rules | `.claude/settings.json`, `CLAUDE.md` |
+| **Project** (optional) | Learned patterns | `.claude/instincts.md` |
 
-| Plugin (shared via `~/.claude/plugins/pds/`) | Project (committed to repo) | User (local) |
-|---|---|---|
-| Skills, agents, hooks | `.claude/settings.json` (team overrides), `CLAUDE.md` | `~/.claude/settings.json` |
-
-Project settings provide team-specific overrides. Plugin provides skills and agents. Deny rules are additive.
-
-### Migration from v3.x
-
-See [Migration Guide](docs/migration-v4.md) for step-by-step instructions.
+Most projects need **zero local PDS files**. The plugin provides everything. Add project-level files only when your team needs custom deny rules or project-specific `CLAUDE.md` rules.
 
 ---
 

--- a/docs/migration-v4.md
+++ b/docs/migration-v4.md
@@ -27,28 +27,20 @@ This installs:
 
 ### 2. Remove project-level PDS files
 
-If your project was using PDS v3.x with project-level installation:
-
 ```bash
-# Remove skills (now in plugin)
-rm -rf .claude/skills/
-
-# Remove agents (now in plugin)
-rm -rf .claude/agents/
-
-# Remove hooks from settings.json (now in plugin)
-# Edit .claude/settings.json and remove the "hooks" key
-# Keep: sandbox, permissions, env sections
+cd ~/your-project
+curl -sfL https://raw.githubusercontent.com/rmzi/portable-dev-system/main/install.sh | bash -s -- --cleanup
 ```
 
-### 3. Keep project-level files
+This removes `.claude/skills/`, `.claude/agents/`, hooks from `settings.json`, and `.pds-version`. It keeps `CLAUDE.md`, `instincts.md`, and any custom settings.
 
-These stay at project level — they are team/project-specific:
+### 3. Keep project-level files (optional)
 
+These stay at project level only if your team needs them:
+
+- `CLAUDE.md` — project rules, agent zones
 - `.claude/settings.json` — team-specific deny rules, domain overrides
 - `.claude/instincts.md` — project-learned patterns
-- `CLAUDE.md` — project rules, agent zones
-- `.claude/.pds-version` — version tracking
 
 ### 4. Update CLAUDE.md skill references
 

--- a/install.sh
+++ b/install.sh
@@ -42,6 +42,7 @@ Options:
   --project     Install project-level settings only (team overrides)
   --plugin-dir  Link a local PDS checkout as the plugin (dev mode)
   --force       Reinstall even if already up to date
+  --cleanup     Remove old v3.x project-level PDS files (skills, agents, hooks)
   --test        Run smoke tests in a temp directory (no network)
   --help        Show this help message
 
@@ -233,6 +234,64 @@ install_project() {
   echo "    curl -sfL https://raw.githubusercontent.com/rmzi/portable-dev-system/main/install.sh | bash"
 }
 
+# --- Cleanup old v3.x project files ---
+
+cleanup_project() {
+  removed=0
+
+  if [ -d ".claude/skills" ]; then
+    rm -rf ".claude/skills"
+    ok "Removed .claude/skills/ (now in plugin)"
+    removed=$((removed + 1))
+  fi
+
+  if [ -d ".claude/agents" ]; then
+    rm -rf ".claude/agents"
+    ok "Removed .claude/agents/ (now in plugin)"
+    removed=$((removed + 1))
+  fi
+
+  if [ -f ".claude/settings.json" ] && grep -q '"hooks"' ".claude/settings.json" 2>/dev/null; then
+    # Remove hooks key from settings.json (now in plugin hooks/hooks.json)
+    if command -v python3 >/dev/null 2>&1; then
+      python3 -c "
+import json, sys
+with open('.claude/settings.json') as f: d = json.load(f)
+d.pop('hooks', None)
+with open('.claude/settings.json', 'w') as f: json.dump(d, f, indent=2); f.write('\n')
+"
+      ok "Removed hooks from .claude/settings.json (now in plugin)"
+      removed=$((removed + 1))
+    else
+      warn "Found hooks in .claude/settings.json — remove manually (python3 not available)"
+    fi
+  fi
+
+  if [ -f ".claude/.pds-version" ]; then
+    rm -f ".claude/.pds-version"
+    ok "Removed .claude/.pds-version (plugin tracks its own version)"
+    removed=$((removed + 1))
+  fi
+
+  # Check if .claude/ is now empty (only settings.json and instincts.md may remain)
+  remaining=$(ls -A .claude/ 2>/dev/null | grep -v 'settings.json' | grep -v 'instincts.md' | grep -v 'agent-memory' | wc -l | tr -d ' ')
+  if [ "$remaining" -eq 0 ] && [ ! -f ".claude/settings.json" ] && [ ! -f ".claude/instincts.md" ]; then
+    rm -rf .claude
+    ok "Removed empty .claude/ directory"
+  fi
+
+  echo ""
+  if [ "$removed" -gt 0 ]; then
+    ok "Cleaned up $removed old PDS artifacts"
+    echo "    Remaining project files (if any):"
+    echo "      .claude/settings.json — team-specific deny rules (keep if customized)"
+    echo "      .claude/instincts.md — project-learned patterns (keep)"
+    echo "      CLAUDE.md — project rules (keep)"
+  else
+    ok "Nothing to clean up — project is already clean"
+  fi
+}
+
 # --- Self-test ---
 
 run_tests() {
@@ -366,6 +425,7 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --project)    MODE="project"; shift ;;
     --plugin-dir) MODE="plugin-dir"; PLUGIN_DIR="$2"; shift 2 ;;
+    --cleanup)    MODE="cleanup"; shift ;;
     --force)      FORCE=1; shift ;;
     --test)       MODE="test"; shift ;;
     --help)       usage ;;
@@ -380,6 +440,12 @@ done
 if [ "$MODE" = "test" ]; then
   run_tests
   exit $?
+fi
+
+# --- Cleanup mode ---
+if [ "$MODE" = "cleanup" ]; then
+  cleanup_project
+  exit 0
 fi
 
 # --- Dev plugin-dir mode ---


### PR DESCRIPTION
## Summary
- README updated with marketplace install as primary method
- `install.sh --cleanup` removes old v3.x project files
- Migration guide references --cleanup

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>