### PR TITLE
feat: add PDS defaults for worktree, auto mode, memory, and UX settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -135,6 +135,36 @@
       "Use /pds:team to see available agents and roles"
     ]
   },
+  "worktree": {
+    "symlinkDirectories": ["node_modules", ".cache", ".bin", ".venv", "__pycache__"]
+  },
+  "autoMode": {
+    "allow": [
+      "Creating git worktrees",
+      "Running tests and linters",
+      "Reading and searching files",
+      "Creating and switching branches",
+      "Installing dependencies"
+    ],
+    "soft_deny": [
+      "Force pushing to any branch",
+      "Deleting branches without confirmation",
+      "Modifying CI/CD pipelines",
+      "Pushing to protected branches (main, master, dev, develop)"
+    ],
+    "environment": [
+      "PDS (Portable Dev System) plugin is active with skills and agents",
+      "Worktree-based workflow: branches are isolated in .worktrees/",
+      "Security-hardened: sandbox enabled, credential paths denied"
+    ]
+  },
+  "showClearContextOnPlanAccept": true,
+  "plansDirectory": ".claude/plans",
+  "showThinkingSummaries": true,
+  "defaultView": "chat",
+  "autoMemoryEnabled": true,
+  "autoDreamEnabled": true,
+  "fastModePerSessionOptIn": true,
   "attribution": {
     "pr": "\n\nGenerated with [PDS](https://github.com/rmzi/portable-dev-system)"
   }

--- a/install.sh
+++ b/install.sh
@@ -272,7 +272,10 @@ if 'env' in pds or 'env' in user:
     user['env'] = merged_env
 
 # PDS-managed keys overwrite (security guardrails + UX)
-for key in ['sandbox', 'permissions', 'spinnerTipsOverride', 'attribution']:
+for key in ['sandbox', 'permissions', 'spinnerTipsOverride', 'attribution',
+            'worktree', 'autoMode', 'showClearContextOnPlanAccept',
+            'plansDirectory', 'showThinkingSummaries', 'defaultView',
+            'autoMemoryEnabled', 'autoDreamEnabled', 'fastModePerSessionOptIn']:
     if key in pds:
         user[key] = pds[key]
 


### PR DESCRIPTION
## Summary
- Adds 9 new default settings to the PDS template (`.claude/settings.json`): worktree symlink dirs, auto mode classifier rules, plans directory, thinking summaries, chat view, auto memory/dream, fast mode per-session opt-in, and clear context on plan accept
- Updates `install.sh` merge logic to propagate all new keys during install
- `teammateMode: tmux` deliberately omitted from template until it lands in the settings schema

## Test plan
- [ ] Run `./install.sh --plugin-dir .` and verify new keys appear in `~/.claude/settings.json`
- [ ] Verify existing user settings are preserved after merge
- [ ] Confirm `worktree.symlinkDirectories` works when creating worktrees
- [ ] Confirm `autoMode` rules appear in `claude auto-mode` output


Generated with [PDS](https://github.com/rmzi/portable-dev-system)