### PR TITLE
fix(agents): raise maxTurns ceilings that silently truncate swarm deliverables

### DIFF
--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -14,7 +14,7 @@ permissionMode: plan
 skills:
   - pds:verify
 color: magenta
-maxTurns: 25
+maxTurns: 50
 memory: project
 ---
 # Reviewer

--- a/agents/scout.md
+++ b/agents/scout.md
@@ -21,7 +21,7 @@ skills:
   - pds:ethos
   - pds:instinct
 color: red
-maxTurns: 15
+maxTurns: 40
 memory: project
 ---
 # Scout

--- a/agents/validator.md
+++ b/agents/validator.md
@@ -19,7 +19,7 @@ skills:
   - pds:verify
   - pds:swarm
 color: yellow
-maxTurns: 40
+maxTurns: 80
 hooks:
   Stop:
     - hooks:


### PR DESCRIPTION
## Summary

Three agents' `maxTurns` ceilings are set below what a real 6-phase swarm consumes, so they exhaust their budget mid-report and return truncated final messages.

Found while running `/pds:swarm` end-to-end on a production repo (a ~1500-line OpenAPI spec resync, 11 acceptance criteria, 2 workers). Measured tool-call counts from that run:

| Agent | `maxTurns` | Tool calls used | Outcome |
|---|---|---|---|
| `scout` | 15 | **27** | Report never reached the orchestrator — Phase 6 deliverable lost |
| `reviewer` | 25 | **39** | Truncated; recovered after a manual follow-up `SendMessage` |
| `validator` | 40 | **64** | Truncated; recovered after a manual follow-up `SendMessage` |

## Why it matters

The failure is quiet and it lands on the deliverable, not the work.

The validator and reviewer had both finished their actual work — merging, testing, reviewing — and were cut off while writing it up. A follow-up message retrieved it. The scout was worse: its report never arrived at all, so the orchestrator recorded it as a failed agent and substituted its own observations. `scout-report.md` is one of the three artifacts the teardown gate checks for, so losing it degrades the gate to a no-op.

Note also that `scout` runs on haiku, which tends to use *more* tool calls to reach the same result, against the tightest ceiling in the roster.

## Change

```
scout      15 -> 40
reviewer   25 -> 50
validator  40 -> 80
```

Sized above observed usage with headroom, and kept proportionate to existing roster values (`orchestrator: 100`, `shepherd: 80`, `worker: 50`).

These are ceilings, not budgets — raising them costs nothing on runs that don't need the turns, while hitting one silently destroys a report.

## Scope

Frontmatter only, three one-line changes. No behavioral or prompt changes.

## Not included

Other issues from the same run are filed separately rather than bundled here, since they need root-cause discussion rather than a mechanical fix:

- `worker.md` hardcodes `isolation: worktree`, which fails with *"WorktreeCreate hook failed: hook succeeded but returned no worktree path"* — this makes `pds:worker` unspawnable.
- `Agent(name=...)` is rejected for teammate-spawned orchestrators, which breaks the named-worker dispatch pattern documented in `skills/swarm/SKILL.md` Phase 3.
